### PR TITLE
remove unnecessary -m64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIB = $(LIBDIR)/libstructures.a
 TESTOBJ =$(OBJDIR)/tests.o
 HEADERS = $(INCDIR)/suffix_tree.hpp $(INCDIR)/union_find.hpp $(INCDIR)/min_max_heap.hpp $(INCDIR)/immutable_list.hpp $(INCDIR)/stable_double.hpp $(INCDIR)/rank_pairing_heap.hpp
 CXX = g++
-CPPFLAGS += -std=c++11 -m64 -g -O3 -I$(INCSEARCHDIR)
+CPPFLAGS += -std=c++11 -g -O3 -I$(INCSEARCHDIR)
 
 
 all: 


### PR DESCRIPTION
gcc/g++ on some 64 bit architectures doesn't recognize that flag